### PR TITLE
docs: add Linux GPU instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ MODEL=llama3 OLLAMA_BASE_URL=http://host.docker.internal:11434 docker-compose up
 
 This is necessary if you're running RAGapp on macOS, as Docker for Mac does not support GPU acceleration.
 
+To enable Docker access to NVIDIA GPUs on Linux, [install the NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+
 ### Kubernetes
 
 It's easy to deploy RAGapp in your own cloud infrastructure. Customized K8S deployment descriptors are coming soon.


### PR DESCRIPTION
As discussed in https://github.com/ragapp/ragapp/issues/14, the GPU is not utalized by the Ollama docker container out of the box on Ubuntu 24.04. The fix was to [install the NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) as was linked on [the Ollama blog](https://ollama.com/blog/ollama-is-now-available-as-an-official-docker-image) for NVIDIA GPU access in Docker. After that was installed and the Docker daemon restarted, RAGapp worked great with `docker-compose up` on Ubuntu 24.04.

This PR adds a line in the README, linking to the installation instructions for the NVIDIA Container Toolkit.