### PR TITLE
feat: Enhance file upload and removal handling to fix the issue #164

### DIFF
--- a/src/ragapp/admin-ui/sections/config/fileLoader.tsx
+++ b/src/ragapp/admin-ui/sections/config/fileLoader.tsx
@@ -94,10 +94,13 @@ export const KnowledgeFileSection = () => {
     }
     console.log("Uploading files:", toUploadFiles);
 
-    // Change to for loop to upload files one by one
-    for (const file of toUploadFiles) {
+     // Change to for loop to upload files one by one
+    for (let i = 0; i < toUploadFiles.length; i++) {
+      const file = toUploadFiles[i];
       const formData = new FormData();
       formData.append("file", file.blob as Blob);
+      formData.append("fileIndex", (i + 1).toString());
+      formData.append("totalFiles", toUploadFiles.length.toString());
       try {
         await uploadFile(formData);
         setFiles((prevFiles) => {

--- a/src/ragapp/backend/controllers/files.py
+++ b/src/ragapp/backend/controllers/files.py
@@ -29,7 +29,7 @@ class FileHandler:
 
     @classmethod
     async def upload_file(
-        cls, file, file_name: str
+        cls, file, file_name: str, fileIndex: str, totalFiles: str
     ) -> File | UnsupportedFileExtensionError:
         """
         Upload a file to the data folder.
@@ -46,7 +46,9 @@ class FileHandler:
         with open(f"data/{file_name}", "wb") as f:
             f.write(await file.read())
         # Index the data
-        index_all()
+        # Index the data only when it is the last file to upload
+        if fileIndex == totalFiles:
+            index_all()
         return File(name=file_name, status=FileStatus.UPLOADED)
 
     @classmethod

--- a/src/ragapp/backend/routers/management/files.py
+++ b/src/ragapp/backend/routers/management/files.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, UploadFile
+from fastapi import APIRouter, UploadFile, Form
 from fastapi.responses import JSONResponse
 
 from backend.controllers.files import FileHandler, UnsupportedFileExtensionError
@@ -16,11 +16,11 @@ def fetch_files() -> list[File]:
 
 
 @r.post("")
-async def add_file(file: UploadFile):
+async def add_file(file: UploadFile, fileIndex: str= Form(), totalFiles: str= Form()):
     """
     Upload a new file.
     """
-    res = await FileHandler.upload_file(file, str(file.filename))
+    res = await FileHandler.upload_file(file, str(file.filename), fileIndex, totalFiles)
     if isinstance(res, UnsupportedFileExtensionError):
         # Return 400 response with message if the file extension is not supported
         return JSONResponse(


### PR DESCRIPTION
- Updated `FileHandler.upload_file` to accept `fileIndex` and `totalFiles` parameters and index data only when the last file is uploaded.
- Modified `add_file` endpoint in FastAPI to accept `fileIndex` and `totalFiles` as form data.
- Enhanced the file upload logic in the frontend to include `fileIndex` and `totalFiles` in the form data.
- Improved user feedback during file operations in the frontend.

These changes ensure better handling of file uploads and removals, providing a more robust and user-friendly experience.