### PR TITLE
Add validate agent name to avoid OpenAI function calling issue

### DIFF
--- a/.changeset/hot-impalas-care.md
+++ b/.changeset/hot-impalas-care.md
@@ -1,0 +1,5 @@
+---
+"ragbox": patch
+---
+
+Fix name of agent as tool include special characters

--- a/src/ragapp/admin-ui/sections/config/agent.tsx
+++ b/src/ragapp/admin-ui/sections/config/agent.tsx
@@ -144,8 +144,9 @@ export const AgentConfig = () => {
         console.error("Failed to update agent name:", error);
         toast({
           title: "Error",
-          description: "Failed to update agent name. Please try again.",
+          description: `Failed to update agent name. ${error}`,
           variant: "destructive",
+          duration: 10000,
         });
       }
     }

--- a/src/ragapp/backend/agents/orchestrator.py
+++ b/src/ragapp/backend/agents/orchestrator.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Optional
 
 from app.engine.tools import ToolFactory
@@ -45,9 +46,13 @@ def get_agents(
         # The orchestrator uses "role" to select the right agent for a task
         # construct a "description" from the user defined role and goal for better orchestration
         description = f"{agent_config.role}\n and its goals are {agent_config.goal}"
+        # OpenAI only allows agent names to match the pattern '^[a-zA-Z0-9_-]+$'."
+        # Remove special characters from the agent name
+        agent_name = re.sub(r"[^a-zA-Z0-9_-]", "", agent_config.name)
+
         agents.append(
             FunctionCallingAgent(
-                name=agent_config.name,
+                name=agent_name,
                 role=description,
                 system_prompt=system_prompt,
                 tools=tools,

--- a/src/ragapp/backend/controllers/agents.py
+++ b/src/ragapp/backend/controllers/agents.py
@@ -1,4 +1,5 @@
-import threading  # Import threading
+import re
+import threading
 from functools import lru_cache
 from typing import Dict, List, Tuple
 
@@ -234,6 +235,14 @@ class AgentManager:
                 return False
 
         return llm.metadata.is_function_calling_model
+
+    @staticmethod
+    def validate_agent_data(agent_data: Dict):
+        # Validate is agent name valid
+        if not re.match(r"^[a-zA-Z0-9_-]+$", agent_data["name"]):
+            raise ValueError(
+                "Agent name must only contain letters, numbers, underscores, and hyphens"
+            )
 
 
 def agent_manager():

--- a/src/ragapp/backend/routers/management/agents.py
+++ b/src/ragapp/backend/routers/management/agents.py
@@ -67,6 +67,7 @@ def create_agent(
                 status_code=400,
                 detail="Agent mode requires a model supporting function calling but your current model does not support it. Please change to a different model or update your model config.",
             )
+        agent_manager.validate_agent_data(agent_data)
         return agent_manager.create_agent(agent_data)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -82,6 +83,7 @@ def update_agent(
     Update an existing agent.
     """
     try:
+        agent_manager.validate_agent_data(agent_data)
         return agent_manager.update_agent(agent_id, agent_data)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
Got error from OpenAI if the function name include special character (ex: space) - the issue cause by agent name that we're using it as function name
```
    |     raise self._make_status_error_from_response(err.response) from None
    | openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid 'tools[0].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.", 'type': 'invalid_request_error', 'param': 'tools[0].function.name', 'code': 'invalid_value'}}
```